### PR TITLE
Make `Grid1D` and `Grid2D` are now subtypes of `AbstractGrid`

### DIFF
--- a/src/MixedLayerThermoclineDynamics.jl
+++ b/src/MixedLayerThermoclineDynamics.jl
@@ -4,7 +4,9 @@ using DocStringExtensions
 
 export Grid1D, Grid2D
 
-include("grids.jl")
+"Abstract supertype for grids."
+abstract type AbstractGrid end
 
+include("grids.jl")
 
 end # module

--- a/src/MixedLayerThermoclineDynamics.jl
+++ b/src/MixedLayerThermoclineDynamics.jl
@@ -3,10 +3,12 @@ module MixedLayerThermoclineDynamics
 using DocStringExtensions
 
 export Grid1D, Grid2D
+export Field1D, Field2D
 
 "Abstract supertype for grids."
 abstract type AbstractGrid end
 
 include("grids.jl")
+include("fields.jl")
 
 end # module

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -1,0 +1,64 @@
+include("grids.jl")
+
+export Grid1D, Grid2D
+
+
+"""
+    abstract type AbstractLocation
+
+Datatype to store location of variables. Subtypes:
+1. Centre
+2. Face
+"""
+abstract type AbstractLocation end
+
+
+
+"""
+    struct Centre <: AbstractLocation
+
+Datatype to represent a variable on cell centre.
+"""
+struct Centre <: AbstractLocation end 
+
+
+
+"""
+    struct Face <: AbstractLocation
+
+Datatype to represent a variable on cell face.
+"""
+struct Face <: AbstractLocation end
+
+
+
+"""
+    struct Field1D{Locx<:AbstractLocation}
+
+Constructs a field datatype for a 1D variable.
+
+$(TYPEDFIELDS)
+"""
+struct Field1D{Locx<:AbstractLocation}
+	"Array storing the values of a 1D variable"
+    data::Array
+    "Grid properties for 1D variable"
+    grid::Grid1D
+end
+
+
+
+"""
+    struct Field2D{Locx<:AbstractLocation, Locy<:AbstractLocation}
+
+Constructs a field datatype for a 2D variable.
+
+$(TYPEDFIELDS)
+"""
+struct Field2D{Locx<:AbstractLocation, Locy<:AbstractLocation}
+    
+	"Array storing the values of a 2D variable"
+    data::Array
+    "Grid properties for 2D variable"
+    grid::Grid2D
+end

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -1,11 +1,11 @@
 """
-    struct Grid1D
+    struct Grid1D <: AbstractGrid
 
 Returns a one-dimensional staggered `grid`.
 
 $(TYPEDFIELDS)
 """
-struct Grid1D
+struct Grid1D <: AbstractGrid
     "Number of points in x-direction"
     nx::Int
     "Grid spacing in x-direction"
@@ -28,13 +28,13 @@ function Grid1D(nx, x_start, x_end)
 end
 
 """
-    struct Grid2D
+    struct Grid2D <: AbstractGrid
 
 Returns a two-dimensional staggered `grid`.
 
 $(TYPEDFIELDS)
 """
-struct Grid2D
+struct Grid2D <: AbstractGrid
     "Number of points in x-direction"
     nx::Int
     "Number of points in y-direction"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using Test, MixedLayerThermoclineDynamics
 
     @test test_dx(grid1D, dx)
     @test test_xF(grid1D, range(0, stop = Lx - dx, length = nx))
-    @test xdomain_length(grid1D, Lx - 0)
+    @test xdomain_length(grid1D, Lx)
 
     grid2D = Grid2D(nx, ny, 0, Lx, 0, Ly)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,20 +6,22 @@ using Test, MixedLayerThermoclineDynamics
     nx, ny = 10, 12
     Lx, Ly = 2.0, 2.4
     
+    dx, dy = Lx/nx, Ly/ny
+    
     grid1D = Grid1D(nx, 0, Lx)
 
-    @test test_dx(grid1D, Lx/nx)
-    @test test_xF(grid1D, range(0, stop = Lx - grid1D.dx, length = nx))
+    @test test_dx(grid1D, dx)
+    @test test_xF(grid1D, range(0, stop = Lx - dx, length = nx))
     @test xdomain_length(grid1D, Lx - 0)
 
     grid2D = Grid2D(nx, ny, 0, Lx, 0, Ly)
 
-    @test test_dx(grid2D, Lx/nx)
-    @test test_dy(grid2D, Ly/ny)
-    @test test_xC(grid2D, range(grid2D.dx/2, stop = Lx - grid2D.dx/2, length = nx))
-    @test test_xF(grid2D, range(0, stop = Lx - grid2D.dx, length = nx))
-    @test test_yF(grid2D, range(0, stop = Ly - grid2D.dy, length = ny))
-    @test test_yC(grid2D, range(grid2D.dy/2, stop = Ly - grid2D.dy/2, length = ny))
+    @test test_dx(grid2D, dx)
+    @test test_dy(grid2D, dy)
+    @test test_xC(grid2D, range(dx/2, stop = Lx - dx/2, length = nx))
+    @test test_xF(grid2D, range(0, stop = Lx - dx, length = nx))
+    @test test_yF(grid2D, range(0, stop = Ly - dy, length = ny))
+    @test test_yC(grid2D, range(dy/2, stop = Ly - dy/2, length = ny))
     @test xdomain_length(grid2D, Lx)
     @test ydomain_length(grid2D, Ly)
 end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -2,7 +2,7 @@ function test_dx(grid, dx)
     return grid.dx ≈ dx
 end
 
-function test_dy(grid, dy)
+function test_dy(grid::Grid2D, dy)
     return grid.dy ≈ dy
 end
 
@@ -14,11 +14,11 @@ function test_xC(grid, xC)
     return grid.xC ≈ xC
 end
 
-function test_yF(grid, yF)
+function test_yF(grid::Grid2D, yF)
     return grid.yF ≈ yF
 end
 
-function test_yC(grid, yC)
+function test_yC(grid::Grid2D, yC)
     return grid.yC ≈ yC
 end
 
@@ -26,6 +26,6 @@ function xdomain_length(grid, Lx)
     return grid.Lx ≈ Lx
 end
 
-function ydomain_length(grid, Ly)
+function ydomain_length(grid::Grid2D, Ly)
     return grid.Ly ≈ Ly
 end


### PR DESCRIPTION
This PR makes both composite types `Grid1D` and `Grid2D` subtypes of `AbstractGrid`. Also, enhances some test to make them slightly more robust.

These changes shouldn't be breaking anything.