### PR TITLE
Make `Grid1D` and `Grid2D` are now subtypes of `AbstractGrid`

### DIFF
--- a/src/MixedLayerThermoclineDynamics.jl
+++ b/src/MixedLayerThermoclineDynamics.jl
@@ -4,7 +4,9 @@ using DocStringExtensions
 
 export Grid1D, Grid2D
 
-include("grids.jl")
+"Abstract supertype for grids."
+abstract type AbstractGrid end
 
+include("grids.jl")
 
 end # module

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -1,11 +1,11 @@
 """
-    struct Grid1D
+    struct Grid1D <: AbstractGrid
 
 Returns a one-dimensional staggered `grid`.
 
 $(TYPEDFIELDS)
 """
-struct Grid1D
+struct Grid1D <: AbstractGrid
     "Number of points in x-direction"
     nx::Int
     "Grid spacing in x-direction"
@@ -28,13 +28,13 @@ function Grid1D(nx, x_start, x_end)
 end
 
 """
-    struct Grid2D
+    struct Grid2D <: AbstractGrid
 
 Returns a two-dimensional staggered `grid`.
 
 $(TYPEDFIELDS)
 """
-struct Grid2D
+struct Grid2D <: AbstractGrid
     "Number of points in x-direction"
     nx::Int
     "Number of points in y-direction"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,20 +6,22 @@ using Test, MixedLayerThermoclineDynamics
     nx, ny = 10, 12
     Lx, Ly = 2.0, 2.4
     
+    dx, dy = Lx/nx, Ly/ny
+    
     grid1D = Grid1D(nx, 0, Lx)
 
-    @test test_dx(grid1D, Lx/nx)
-    @test test_xF(grid1D, range(0, stop = Lx - grid1D.dx, length = nx))
+    @test test_dx(grid1D, dx)
+    @test test_xF(grid1D, range(0, stop = Lx - dx, length = nx))
     @test xdomain_length(grid1D, Lx - 0)
 
     grid2D = Grid2D(nx, ny, 0, Lx, 0, Ly)
 
-    @test test_dx(grid2D, Lx/nx)
-    @test test_dy(grid2D, Ly/ny)
-    @test test_xC(grid2D, range(grid2D.dx/2, stop = Lx - grid2D.dx/2, length = nx))
-    @test test_xF(grid2D, range(0, stop = Lx - grid2D.dx, length = nx))
-    @test test_yF(grid2D, range(0, stop = Ly - grid2D.dy, length = ny))
-    @test test_yC(grid2D, range(grid2D.dy/2, stop = Ly - grid2D.dy/2, length = ny))
+    @test test_dx(grid2D, dx)
+    @test test_dy(grid2D, dy)
+    @test test_xC(grid2D, range(dx/2, stop = Lx - dx/2, length = nx))
+    @test test_xF(grid2D, range(0, stop = Lx - dx, length = nx))
+    @test test_yF(grid2D, range(0, stop = Ly - dy, length = ny))
+    @test test_yC(grid2D, range(dy/2, stop = Ly - dy/2, length = ny))
     @test xdomain_length(grid2D, Lx)
     @test ydomain_length(grid2D, Ly)
 end

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -2,7 +2,7 @@ function test_dx(grid, dx)
     return grid.dx ≈ dx
 end
 
-function test_dy(grid, dy)
+function test_dy(grid::Grid2D, dy)
     return grid.dy ≈ dy
 end
 
@@ -14,11 +14,11 @@ function test_xC(grid, xC)
     return grid.xC ≈ xC
 end
 
-function test_yF(grid, yF)
+function test_yF(grid::Grid2D, yF)
     return grid.yF ≈ yF
 end
 
-function test_yC(grid, yC)
+function test_yC(grid::Grid2D, yC)
     return grid.yC ≈ yC
 end
 
@@ -26,6 +26,6 @@ function xdomain_length(grid, Lx)
     return grid.Lx ≈ Lx
 end
 
-function ydomain_length(grid, Ly)
+function ydomain_length(grid::Grid2D, Ly)
     return grid.Ly ≈ Ly
 end


### PR DESCRIPTION
This PR makes both composite types `Grid1D` and `Grid2D` subtypes of `AbstractGrid`. Also, enhances some test to make them slightly more robust.

These changes shouldn't be breaking anything.

@dhruvbhagtani, review this at your convenience.
Let's implement `Fields` in a different PR. You can open that while this is open.