### PR TITLE
Adds Topology and halo points in Grids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,11 @@ version = "0.1.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
 DocStringExtensions = "0.8"
+OffsetArrays = "1.10"
 julia = "^1.6"
 
 [extras]

--- a/src/MixedLayerThermoclineDynamics.jl
+++ b/src/MixedLayerThermoclineDynamics.jl
@@ -4,6 +4,9 @@ using DocStringExtensions
 
 export
   AbstractGrid,
+  AbstractTopology,
+  Periodic,
+  Bounded,
   Grid1D,
   Grid2D,
   
@@ -16,6 +19,15 @@ export
   Field1D,
   Field2D,
   Field
+
+""" Abstract supertype for topology of grids. """
+abstract type AbstractTopology end
+
+""" Type for location at the cell centres. """
+struct Periodic <: AbstractTopology end 
+
+""" Type for location at the cell centres. """
+struct Bounded <: AbstractTopology end 
 
 """ Abstract supertype for grids. """
 abstract type AbstractGrid end

--- a/src/MixedLayerThermoclineDynamics.jl
+++ b/src/MixedLayerThermoclineDynamics.jl
@@ -1,6 +1,8 @@
 module MixedLayerThermoclineDynamics
 
-using DocStringExtensions
+using
+  DocStringExtensions,
+  OffsetArrays
 
 export
   AbstractGrid,

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -27,7 +27,9 @@ Construct a one-dimensional staggered `grid` on domain `x ∈ [x_start, x_end]` 
 """
 function Grid1D(Tx, nx, x_start, x_end; hx=0)
     Lx = x_end - x_start
+    
     dx = Lx/nx
+    
     xF = construct_faces(Tx, nx, hx, dx, Lx, x_start)
     xC = construct_centres(Tx, nx, hx, dx, Lx, x_start)
 
@@ -77,8 +79,9 @@ with topologies `{Tx, Ty}`, with `{nx, ny}` interior grid points, and `{hx, hy}`
 function Grid2D(Tx, Ty, nx, ny, x_start, x_end, y_start, y_end; hx=0, hy=0)
     Lx = x_end - x_start
     Ly = y_end - y_start
-    dx = Lx/nx
-    dy = Ly/ny
+    
+    dx, dy = Lx/nx, Ly/ny
+    
     xF = construct_faces(Tx, nx, hx, dx, Lx, x_start)
     xC = construct_centres(Tx, nx, hx, dx, Lx, x_start)
     yF = construct_faces(Ty, ny, hy, dy, Ly, y_start)
@@ -97,9 +100,9 @@ Returns the face locations for a dimension with topology `T`, number of grid poi
 halo points, grid spacing `d`, and extent `L`.
 """
 function construct_faces(T::AbstractTopology, n, h, d, L, start)
-    start_face = start
-    end_face = isa(T, Periodic) ? start + L - d : start + L
-    total_faces = isa(T, Periodic) ? n : n + 1
+    start_face  = start
+      end_face  = isa(T, Periodic) ? start + L - d : start + L
+    total_faces = isa(T, Periodic) ? n             : n + 1
     
     F = range(start_face - h*d, stop = end_face + h*d, length = total_faces + 2h)
     
@@ -114,7 +117,7 @@ Returns the cell centers locations for a dimension with topology `T`, number of 
 """
 function construct_centres(T::AbstractTopology, n, h, d, L, start)
     start_center = start + d/2
-    end_center = start + L - d/2
+      end_center = start + L - d/2
     
     C = range(start_center - h*d, stop = end_center + h*d, length = n + 2h)
     

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -84,16 +84,11 @@ end
 
 Returns the face locations for a dimension with topology `T`, number of grid points `n` and `h`
 halo points, grid spacing `d`, and extent `L`.
-
-$(TYPEDFIELDS)
 """
 function construct_faces(T::AbstractTopology, n, h, d, L, startface)
     
-    if isa(T, Periodic)
-        F = range(startface - h*d, stop = L - d + h*d, length = n + 2h)
-    elseif isa(T, Bounded)
-        F = range(startface - h*d, stop = L + h*d, length = n + 1 + 2h)
-    end
+    end_face = isa(T, Periodic) ? L - d : L
+    total_faces = isa(T, Periodic) ? n : n + 1
     
-    return F
+    return range(startface - h*d, stop = end_face + h*d, length = total_faces)
 end

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -15,22 +15,27 @@ struct Grid1D{Tx<:AbstractTopology} <: AbstractGrid
     "Domain extent in x-direction"
     Lx::Float64
     "Cell faces in x-direction"
-    xF::Vector
+    xF::AbstractArray
     "Cell centres in x-direction"
-    xC::Vector
+    xC::AbstractArray
 end
 
+"""
+    Grid1D(Tx, nx, x_start, x_end; hx=0)
+Construct a one-dimensional staggered `grid` on domain `x ∈ [x_start, x_end]` with topology
+`Tx`, with `nx` interior grid points, and `hx` halo points.
+"""
 function Grid1D(Tx, nx, x_start, x_end; hx=0)
     Lx = x_end - x_start
     dx = Lx/nx
     xF = construct_faces(Tx, nx, hx, dx, Lx, x_start)
-    xC = xF .+ dx/2
+    xC = construct_centres(Tx, nx, hx, dx, Lx, x_start)
 
     return Grid1D{typeof(Tx)}(nx, hx, dx, Lx, xF, xC)
 end
 
 """
-    Grid2D{Tx<:AbstractTopology, Ty<:AbstractTopology} <: AbstractGrid
+    struct Grid2D{Tx<:AbstractTopology, Ty<:AbstractTopology} <: AbstractGrid
 
 Returns a two-dimensional staggered `grid` with topologies `{Tx, Ty}`.
 
@@ -54,24 +59,30 @@ struct Grid2D{Tx<:AbstractTopology, Ty<:AbstractTopology} <: AbstractGrid
     "Domain extent in y-direction"
     Ly::Float64
     "Cell faces in x-direction"
-    xF::Vector
+    xF::AbstractArray
     "Cell centres in x-direction"
-    xC::Vector
+    xC::AbstractArray
     "Cell faces in y-direction"
-    yF::Vector
+    yF::AbstractArray
     "Cell centres in y-direction"
-    yC::Vector
+    yC::AbstractArray
 end
 
+"""
+    Grid2D(Tx, Ty, nx, ny, x_start, x_end, y_start, y_end; hx=0, hy=0)
+
+Construct a two-dimensional staggered `grid` on domain `(x, y) ∈ [x_start, x_end] x [y_start, y_end]`
+with topologies `{Tx, Ty}`, with `{nx, ny}` interior grid points, and `{hx, hy}` halo points.
+"""
 function Grid2D(Tx, Ty, nx, ny, x_start, x_end, y_start, y_end; hx=0, hy=0)
     Lx = x_end - x_start
     Ly = y_end - y_start
     dx = Lx/nx
     dy = Ly/ny
     xF = construct_faces(Tx, nx, hx, dx, Lx, x_start)
-    xC = xF .+ dx/2
+    xC = construct_centres(Tx, nx, hx, dx, Lx, x_start)
     yF = construct_faces(Ty, ny, hy, dy, Ly, y_start)
-    yC = yF .+ dy/2
+    yC = construct_centres(Ty, ny, hy, dy, Ly, y_start)
     
     return Grid2D{typeof(Tx), typeof(Ty)}(nx, ny, hx, hy, dx, dy, Lx, Ly, xF, xC, yF, yC)
 end
@@ -85,10 +96,27 @@ end
 Returns the face locations for a dimension with topology `T`, number of grid points `n` and `h`
 halo points, grid spacing `d`, and extent `L`.
 """
-function construct_faces(T::AbstractTopology, n, h, d, L, startface)
-    
-    end_face = isa(T, Periodic) ? L - d : L
+function construct_faces(T::AbstractTopology, n, h, d, L, start)
+    start_face = start
+    end_face = isa(T, Periodic) ? start + L - d : start + L
     total_faces = isa(T, Periodic) ? n : n + 1
     
-    return range(startface - h*d, stop = end_face + h*d, length = total_faces)
+    F = range(start_face - h*d, stop = end_face + h*d, length = total_faces + 2h)
+    
+    return OffsetArray(F, -h)
+end
+
+"""
+    construct_centres(T::AbstractTopology, n, h, d, L, start_center)
+
+Returns the cell centers locations for a dimension with topology `T`, number of grid points
+`n` and `h` halo points, grid spacing `d`, and extent `L`.
+"""
+function construct_centres(T::AbstractTopology, n, h, d, L, start)
+    start_center = start + d/2
+    end_center = start + L - d/2
+    
+    C = range(start_center - h*d, stop = end_center + h*d, length = n + 2h)
+    
+    return OffsetArray(C, -h)
 end

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -1,13 +1,15 @@
 """
-    struct Grid1D <: AbstractGrid
+    struct Grid1D{Tx<:AbstractTopology} <: AbstractGrid
 
-Returns a one-dimensional staggered `grid`.
+Returns a one-dimensional staggered `grid` with topology `Tx`.
 
 $(TYPEDFIELDS)
 """
-struct Grid1D <: AbstractGrid
+struct Grid1D{Tx<:AbstractTopology} <: AbstractGrid
     "Number of points in x-direction"
     nx::Int
+    "Number of halo points in x-direction"
+    hx::Int
     "Grid spacing in x-direction"
     dx::Float64
     "Domain extent in x-direction"
@@ -18,27 +20,31 @@ struct Grid1D <: AbstractGrid
     xC::Vector
 end
 
-function Grid1D(nx, x_start, x_end)
+function Grid1D(Tx, nx, x_start, x_end; hx=0)
     Lx = x_end - x_start
     dx = Lx/nx
-    xF = range(x_start, stop = x_end-dx, length = nx)
+    xF = construct_faces(Tx, nx, hx, dx, Lx, x_start)
     xC = xF .+ dx/2
 
-    return Grid1D(nx, dx, Lx, xF, xC)
+    return Grid1D{typeof(Tx)}(nx, hx, dx, Lx, xF, xC)
 end
 
 """
-    struct Grid2D <: AbstractGrid
+    Grid2D{Tx<:AbstractTopology, Ty<:AbstractTopology} <: AbstractGrid
 
-Returns a two-dimensional staggered `grid`.
+Returns a two-dimensional staggered `grid` with topologies `{Tx, Ty}`.
 
 $(TYPEDFIELDS)
 """
-struct Grid2D <: AbstractGrid
+struct Grid2D{Tx<:AbstractTopology, Ty<:AbstractTopology} <: AbstractGrid
     "Number of points in x-direction"
     nx::Int
     "Number of points in y-direction"
     ny::Int
+    "Number of halo points in x-direction"
+    hx::Int
+    "Number of halo points in y-direction"
+    hy::Int
     "Grid spacing in x-direction"
     dx::Float64
     "Grid spacing in y-direction"
@@ -57,15 +63,37 @@ struct Grid2D <: AbstractGrid
     yC::Vector
 end
 
-function Grid2D(nx, ny, x_start, x_end, y_start, y_end)
+function Grid2D(Tx, Ty, nx, ny, x_start, x_end, y_start, y_end; hx=0, hy=0)
     Lx = x_end - x_start
     Ly = y_end - y_start
     dx = Lx/nx
     dy = Ly/ny
-    xF = range(x_start, stop = x_end - dx, length = nx)
+    xF = construct_faces(Tx, nx, hx, dx, Lx, x_start)
     xC = xF .+ dx/2
-    yF = range(y_start, stop = y_end - dy, length = ny)
+    yF = construct_faces(Ty, ny, hy, dy, Ly, y_start)
     yC = yF .+ dy/2
     
-    return Grid2D(nx, ny, dx, dy, Lx, Ly, xF, xC, yF, yC)
+    return Grid2D{typeof(Tx), typeof(Ty)}(nx, ny, hx, hy, dx, dy, Lx, Ly, xF, xC, yF, yC)
+end
+
+##
+# helper functions
+
+"""
+    construct_faces(T::AbstractTopology, n, h, d, L)
+
+Returns the face locations for a dimension with topology `T`, number of grid points `n` and `h`
+halo points, grid spacing `d`, and extent `L`.
+
+$(TYPEDFIELDS)
+"""
+function construct_faces(T::AbstractTopology, n, h, d, L, startface)
+    
+    if isa(T, Periodic)
+        F = range(startface - h*d, stop = L - d + h*d, length = n + 2h)
+    elseif isa(T, Bounded)
+        F = range(startface - h*d, stop = L + h*d, length = n + 1 + 2h)
+    end
+    
+    return F
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,13 +8,13 @@ using Test, MixedLayerThermoclineDynamics
     
     dx, dy = Lx/nx, Ly/ny
     
-    grid1D = Grid1D(nx, 0, Lx)
+    grid1D = Grid1D(Periodic(), nx, 0, Lx)
 
     @test test_dx(grid1D, dx)
     @test test_xF(grid1D, range(0, stop = Lx - dx, length = nx))
     @test xdomain_length(grid1D, Lx)
 
-    grid2D = Grid2D(nx, ny, 0, Lx, 0, Ly)
+    grid2D = Grid2D(Periodic(), Periodic(), nx, ny, 0, Lx, 0, Ly)
 
     @test test_dx(grid2D, dx)
     @test test_dy(grid2D, dy)
@@ -32,8 +32,8 @@ end
     
     dx, dy = Lx/nx, Ly/ny
     
-    grid1D = Grid1D(nx, 0, Lx)
-    grid2D = Grid2D(nx, ny, 0, Lx, 0, Ly)
+    grid1D = Grid1D(Periodic(), nx, 0, Lx)
+    grid2D = Grid2D(Periodic(), Periodic(), nx, ny, 0, Lx, 0, Ly)
     
     # 1D Fields
     hdata = @. sin(2π * grid1D.xC / Lx)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,29 +1,50 @@
-using Test, MixedLayerThermoclineDynamics
+using MixedLayerThermoclineDynamics, OffsetArrays, Test
 
 @time @testset "Grid tests" begin
     include("test_grids.jl")
-
-    nx, ny = 10, 12
-    Lx, Ly = 2.0, 2.4
     
-    dx, dy = Lx/nx, Ly/ny
-    
-    grid1D = Grid1D(Periodic(), nx, 0, Lx)
+    for Tx in (Periodic(), Bounded()), Ty in (Periodic(), Bounded())
+        
+        nx, ny = 10, 12
+        hx, hy =  1, 2
+        x0, y0 = 0.2, -0.4
+        Lx, Ly = 2.0, 2.4
+        
+        dx, dy = Lx/nx, Ly/ny
+        
+        grid1D = Grid1D(Tx, nx, x0, x0 + Lx; hx=hx)        
+        grid2D = Grid2D(Tx, Ty, nx, ny, x0, x0 + Lx, y0, y0 + Ly; hx=hx, hy=hy)
 
-    @test test_dx(grid1D, dx)
-    @test test_xF(grid1D, range(0, stop = Lx - dx, length = nx))
-    @test xdomain_length(grid1D, Lx)
+            
+        xF = isa(Tx, Periodic) ? range(x0 - hx*dx, stop = x0 + Lx - dx + hx*dx, length = nx + 2hx) :
+                                 range(x0 - hx*dx, stop = x0 + Lx + hx*dx, length = nx + 1 + 2hx)
 
-    grid2D = Grid2D(Periodic(), Periodic(), nx, ny, 0, Lx, 0, Ly)
+        xC = range(x0 + dx/2 - hx*dx, stop = x0 + Lx - dx/2 + hx*dx, length = nx + 2hx)
+        
+        yF = isa(Ty, Periodic) ? range(y0 - hy*dy, stop = y0 + Ly - dy + hy*dy, length = ny + 2hy) :
+                                 range(y0 - hy*dy, stop = y0 + Ly + hy*dy, length = ny + 1 + 2hy)
+        
+        yC = range(y0 + dy/2 - hy*dy, stop = y0 + Ly - dy/2 + hy*dy, length = ny + 2hy)
+        
+        xF = OffsetArray(xF, -hx)
+        xC = OffsetArray(xC, -hx)
+        yF = OffsetArray(yF, -hy)
+        yC = OffsetArray(yC, -hy)
+        
+        @test test_dx(grid1D, dx)
+        @test test_xF(grid1D, xF)
+        @test test_xC(grid1D, xC)
+        @test xdomain_length(grid1D, Lx)
 
-    @test test_dx(grid2D, dx)
-    @test test_dy(grid2D, dy)
-    @test test_xC(grid2D, range(dx/2, stop = Lx - dx/2, length = nx))
-    @test test_xF(grid2D, range(0, stop = Lx - dx, length = nx))
-    @test test_yF(grid2D, range(0, stop = Ly - dy, length = ny))
-    @test test_yC(grid2D, range(dy/2, stop = Ly - dy/2, length = ny))
-    @test xdomain_length(grid2D, Lx)
-    @test ydomain_length(grid2D, Ly)
+        @test test_dx(grid2D, dx)
+        @test test_dy(grid2D, dy)
+        @test test_xF(grid2D, xF)
+        @test test_xC(grid2D, xC)
+        @test test_yF(grid2D, yF)
+        @test test_yC(grid2D, yC)
+        @test xdomain_length(grid2D, Lx)
+        @test ydomain_length(grid2D, Ly)
+    end
 end
 
 @time @testset "Field tests" begin

--- a/test/test_grids.jl
+++ b/test/test_grids.jl
@@ -1,31 +1,31 @@
 function test_dx(grid, dx)
-    return grid.dx ≈ dx
+    return grid.dx == dx
 end
 
 function test_dy(grid::Grid2D, dy)
-    return grid.dy ≈ dy
+    return grid.dy == dy
 end
 
 function test_xF(grid, xF)
-    return grid.xF ≈ xF
+    return grid.xF == xF
 end
 
 function test_xC(grid, xC)
-    return grid.xC ≈ xC
+    return grid.xC == xC
 end
 
 function test_yF(grid::Grid2D, yF)
-    return grid.yF ≈ yF
+    return grid.yF == yF
 end
 
 function test_yC(grid::Grid2D, yC)
-    return grid.yC ≈ yC
+    return grid.yC == yC
 end
 
 function xdomain_length(grid, Lx)
-    return grid.Lx ≈ Lx
+    return grid.Lx == Lx
 end
 
 function ydomain_length(grid::Grid2D, Ly)
-    return grid.Ly ≈ Ly
+    return grid.Ly == Ly
 end


### PR DESCRIPTION
This PR adds `Topology` parameter and halo points in Grids.

Topology can be either `Periodic` or `Bounded`.

To do:

- [x] Use OffsetArrays.jl to better handle grids with halo points.
- [x] Generalise tests for both topologies.
- [x] Add tests for proper halo point constructor.