### PR TITLE
Enable doctests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,8 @@ julia = "^1.6"
 
 [extras]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Coverage"]
+test = ["Test", "Documenter", "Coverage"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, MixedLayerThermoclineDynamics
 
 makedocs(modules = [MixedLayerThermoclineDynamics],
         sitename = "MixedLayerThermoclineDynamics.jl",
-        doctests = true,
+         doctest = true,
           strict = :doctest)
 
 deploydocs(        repo = "github.com/ClimateFluidPhysics-ANU/MixedLayerThermoclineDynamics.jl.git",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,11 @@
 using Documenter, MixedLayerThermoclineDynamics
 
-makedocs(modules = [MixedLayerThermoclineDynamics], sitename = "MixedLayerThermoclineDynamics.jl")
+makedocs(modules = [MixedLayerThermoclineDynamics],
+        sitename = "MixedLayerThermoclineDynamics.jl",
+        doctests = true,
+          strict = :doctest)
 
 deploydocs(        repo = "github.com/ClimateFluidPhysics-ANU/MixedLayerThermoclineDynamics.jl.git",
-               versions = ["stable" => "v^", "v#.#", "dev" => "dev"],
+               versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
            push_preview = true
 )

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -102,7 +102,7 @@ Example
 julia> using MixedLayerThermoclineDynamics
 
 julia> grid = Grid2D(Periodic(), Periodic(), 10, 15, 0, 2.0, 0, 3.0)
-1-Dimensional Grid
+2-Dimensional Grid
   ├──── topology in x: Periodic
   ├─ domain extent Lx: 2.0
   ├──── resolution nx: 10
@@ -113,7 +113,7 @@ julia> grid = Grid2D(Periodic(), Periodic(), 10, 15, 0, 2.0, 0, 3.0)
   ├──── resolution ny: 15
   ├── grid spacing dy: 0.2
   └─── halo points ny: 1
-```
+  ```
 """
 function Grid2D(Tx, Ty, nx, ny, x_start, x_end, y_start, y_end; hx=1, hy=1)
 
@@ -177,12 +177,12 @@ show(io::IO, grid::Grid1D{Tx}) where Tx =
 
 show(io::IO, grid::Grid2D{Tx, Ty}) where {Tx, Ty} =
      print(io, "2-Dimensional Grid\n",
-               "  ├─────topology in x: ", Tx, '\n',
+               "  ├──── topology in x: ", Tx, '\n',
                "  ├─ domain extent Lx: ", grid.Lx, '\n',
                "  ├──── resolution nx: ", grid.nx, '\n',
                "  ├── grid spacing dx: ", grid.dx, '\n',
                "  ├─── halo points nx: ", grid.hx, '\n',
-               "  ├─────topology in y: ", Ty, '\n',
+               "  ├──── topology in y: ", Ty, '\n',
                "  ├─ domain extent Ly: ", grid.Ly, '\n',
                "  ├──── resolution ny: ", grid.ny, '\n',
                "  ├── grid spacing dy: ", grid.dy, '\n',

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -113,7 +113,7 @@ julia> grid = Grid2D(Periodic(), Periodic(), 10, 15, 0, 2.0, 0, 3.0)
   ├──── resolution ny: 15
   ├── grid spacing dy: 0.2
   └─── halo points ny: 1
-  ```
+```
 """
 function Grid2D(Tx, Ty, nx, ny, x_start, x_end, y_start, y_end; hx=1, hy=1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using MixedLayerThermoclineDynamics, OffsetArrays, Test
+using MixedLayerThermoclineDynamics, OffsetArrays, Test, Documenter
 
 const rtol_interpolation = 8e-4
 const rtol_derivatives = 8e-4
@@ -229,4 +229,8 @@ end
     @test test_∂y(∂y_CCdata_on_CC_Field2D, CCtest_Field2D, CC_Field2D)
     @test test_∂x(∂x_FCdata_on_FC_Field2D, FCtest_Field2D, FC_Field2D)
     @test test_∂y(∂y_CFdata_on_CF_Field2D, CFtest_Field2D, CF_Field2D)
+end
+
+@time @testset "Doctests" begin
+    doctest(MixedLayerThermoclineDynamics)
 end


### PR DESCRIPTION
This PR actually enables doctests (they were turned off). Also, it makes small fixes in the show() methods for grids so that now actually the doctests in the grid examples pass.